### PR TITLE
Temporary hide draft or test manuals

### DIFF
--- a/consts/hidden-manuals.js
+++ b/consts/hidden-manuals.js
@@ -1,0 +1,3 @@
+const HIDDEN_MANUALS = ['typical', 'typical-2', 'street-name-plates']
+
+export default HIDDEN_MANUALS

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,13 @@
 			"dependencies": {
 				"bootstrap": "5.1.3",
 				"classnames": "2.3.1",
-				"eslint-config-next": "13.0.2",
+				"eslint-config-next": "^13.0.2",
 				"lodash": "4.17.21",
 				"next": "13.0.2",
 				"normalize.css": "8.0.1",
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
-				"react-responsive": "9.0.0",
+				"react-responsive": "^9.0.0",
 				"superagent": "7.1.1",
 				"typograf": "6.14.1"
 			},

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -3,9 +3,7 @@ import React, { useState, useEffect } from 'react'
 import styles from '../styles/home.module.css'
 import { getTree } from '../api/apiPage'
 import Manual from '../components/Manual/Manual'
-
-// TODO Remove hard-code after back-end feature https://github.com/ekaterinburgdev/guides-api/issues/10
-const HIDDEN_MANUALS = ['typical', 'typical-2', 'street-name-plates']
+import HIDDEN_MANUALS from '../consts/hidden-manuals'
 
 export default function Home({ tree }) {
     const [manuals, setManuals] = useState([])
@@ -16,6 +14,7 @@ export default function Home({ tree }) {
             return
         }
 
+        // TODO Remove hard-code after back-end feature https://github.com/ekaterinburgdev/guides-api/issues/10
         const manualsVisible = tree.children.filter((manual) => {
             return !HIDDEN_MANUALS.includes(manual?.properties?.pageUrl?.url)
         })

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -4,6 +4,9 @@ import styles from '../styles/home.module.css'
 import { getTree } from '../api/apiPage'
 import Manual from '../components/Manual/Manual'
 
+// TODO Remove hard-code after back-end feature https://github.com/ekaterinburgdev/guides-api/issues/10
+const HIDDEN_MANUALS = ['typical', 'typical-2', 'street-name-plates']
+
 export default function Home({ tree }) {
     const [manuals, setManuals] = useState([])
     const [title, setTitle] = useState('')
@@ -13,7 +16,11 @@ export default function Home({ tree }) {
             return
         }
 
-        setManuals(tree.children)
+        const manualsVisible = tree.children.filter((manual) => {
+            return !HIDDEN_MANUALS.includes(manual?.properties?.pageUrl?.url)
+        })
+
+        setManuals(manualsVisible)
         setTitle(tree?.properties?.child_page?.title)
     }, [tree])
 


### PR DESCRIPTION
- [x] Hard coded 3 values for draft and test (typical) manuals
- [x] Add `// TODO` comment for remove hard coded value after task https://github.com/ekaterinburgdev/guides-api/issues/10