### PR TITLE
Add support for `/catalog/_index` pages

### DIFF
--- a/consts/hidden-manuals.js
+++ b/consts/hidden-manuals.js
@@ -1,3 +1,0 @@
-const HIDDEN_MANUALS = ['typical', 'typical-2']
-
-export default HIDDEN_MANUALS

--- a/consts/manuals.js
+++ b/consts/manuals.js
@@ -1,0 +1,2 @@
+export const MANUAL_INDEX_PAGE = '_index'
+export const MANUALS_HIDDEN = ['typical', 'typical-2']

--- a/next.config.js
+++ b/next.config.js
@@ -6,9 +6,13 @@ const nextConfig = {
     async rewrites() {
         return [
             {
+                source: '/:pageUrl',
+                destination: '/:pageUrl/_index',
+            },
+            {
                 source: '/:pageUrl*',
                 destination: '/manuals/:pageUrl*',
-            },
+            }
         ]
     },
 }

--- a/utils/getManualToc.js
+++ b/utils/getManualToc.js
@@ -1,4 +1,4 @@
-function getTocList(tree, pageUrl) {
+function getManualToc(tree, pageUrl) {
     if (!tree.children || !pageUrl) {
         return []
     }
@@ -13,7 +13,7 @@ function getTocList(tree, pageUrl) {
                 currentPageChildren.find((obj) => obj.url === currentPageUrl)?.children || []
         }
 
-        currentChildren = currentChildren.find(
+        currentChildren = currentChildren?.find(
             (obj) => obj?.properties?.pageUrl?.url === currentPageUrl
         )?.children
 
@@ -33,4 +33,4 @@ function getTocList(tree, pageUrl) {
     return tableOfContentArrForSet || []
 }
 
-export default getTocList
+export default getManualToc

--- a/utils/getTocList.js
+++ b/utils/getTocList.js
@@ -1,0 +1,36 @@
+function getTocList(tree, pageUrl) {
+    if (!tree.children || !pageUrl) {
+        return []
+    }
+
+    let currentChildren = tree.children
+    let tableOfContentArrForSet = []
+    let currentPageChildren
+
+    for (const currentPageUrl of pageUrl) {
+        if (currentPageChildren) {
+            currentPageChildren =
+                currentPageChildren.find((obj) => obj.url === currentPageUrl)?.children || []
+        }
+
+        currentChildren = currentChildren.find(
+            (obj) => obj?.properties?.pageUrl?.url === currentPageUrl
+        )?.children
+
+        const b = currentChildren?.map((obj) => ({
+            url: obj?.properties?.pageUrl?.url,
+            title: obj?.properties?.Name?.title[0]?.text?.content,
+            children: [],
+        }))
+
+        if (!currentPageChildren) {
+            tableOfContentArrForSet = b
+            currentPageChildren = tableOfContentArrForSet
+        } else {
+            currentPageChildren = b
+        }
+    }
+    return tableOfContentArrForSet || []
+}
+
+export default getTocList

--- a/utils/notionTypeParser/manualsPreviewParser.js
+++ b/utils/notionTypeParser/manualsPreviewParser.js
@@ -1,12 +1,12 @@
 import tp from '../typograf/typograf.config'
 
-import HIDDEN_MANUALS from '../../consts/hidden-manuals'
+import { MANUALS_HIDDEN } from '../../consts/manuals'
 import { API_HOST } from '../../consts/endpoints'
 
 function parseManualsPreview(tree) {
     // TODO Remove hard-code after back-end feature https://github.com/ekaterinburgdev/guides-api/issues/10
     const manualsVisible = tree.children.filter((manual) => {
-        return !HIDDEN_MANUALS.includes(manual?.properties?.pageUrl?.url)
+        return !MANUALS_HIDDEN.includes(manual?.properties?.pageUrl?.url)
     })
 
     return manualsVisible
@@ -30,7 +30,7 @@ function parseManualsPreview(tree) {
                 title: tp.execute(Name?.title[0]?.text?.content || ''),
                 subtitle: tp.execute(subtitle?.rich_text[0]?.plain_text || ''),
                 pageUrl: pageUrl?.url || null,
-                color: color?.rich_text[0].plain_text || null,
+                color: color?.rich_text[0]?.plain_text || null,
                 status: status?.select?.name || null,
                 publishedDate: publishedDate?.date?.start || null,
                 pattern: `${API_HOST}/static/${previewPattern}`,


### PR DESCRIPTION
Now we fill in the content of the main page of the guide in the page with the address `_index`

- [x] Redirect `/catalog` to `catalog/_index` pageUrl or 1st page from TOC 

**Additional**
- [x] Move `getManualToc(tree, pageUrl)` on `getServerSideProps` for fastest loading.
- [x] Show 404 error instead 500. If guide not found https://guides.ekaterinburg.io/not-exist-guide