### PR TITLE
Show bg opened `<ManualPreview>` as color instead img

### DIFF
--- a/components/ManualPreview/ManualPreview.jsx
+++ b/components/ManualPreview/ManualPreview.jsx
@@ -3,21 +3,12 @@ import Link from 'next/link'
 import cn from 'classnames'
 import Image from 'next/image'
 
-import getBackgroundColor from '../../utils/getBackgroundColor'
+import getManualColorScheme from '../../utils/getManualColorScheme'
 
 import styles from './ManualPreview.module.css'
 
-function ManualPreview({
-    title,
-    subtitle,
-    pageUrl,
-    color,
-    status,
-    publishedDate,
-    pattern,
-    image,
-    cover,
-}) {
+function ManualPreview({ title, subtitle, pageUrl, color, status, publishedDate, pattern, image }) {
+    const colorScheme = getManualColorScheme(color)
     return (
         <Link
             href={{
@@ -25,13 +16,13 @@ function ManualPreview({
                 query: { pageUrl: [pageUrl] },
             }}
             className={styles.manual}
+            style={{ background: colorScheme.bgDark }}
         >
-            <Image src={cover} fill alt="" />
             <div className={styles.manualInner} style={{ color }}>
                 <div
                     className={styles.manualBackground}
                     style={{
-                        backgroundColor: getBackgroundColor(color),
+                        backgroundColor: colorScheme.bgLight,
                         backgroundImage: pattern && `url(${pattern})`,
                     }}
                 />

--- a/components/ManualPreview/ManualPreview.jsx
+++ b/components/ManualPreview/ManualPreview.jsx
@@ -18,7 +18,7 @@ function ManualPreview({ title, subtitle, pageUrl, color, status, publishedDate,
             className={styles.manual}
             style={{ background: colorScheme.bgDark }}
         >
-            <div className={styles.manualInner} style={{ color }}>
+            <div className={styles.manualInner} style={{ color: colorScheme.title }}>
                 <div
                     className={styles.manualBackground}
                     style={{

--- a/components/ManualPreview/ManualPreview.module.css
+++ b/components/ManualPreview/ManualPreview.module.css
@@ -51,10 +51,15 @@
 
 .manualIcon {
     position: absolute;
-    width: 1.75em;
+    width: 100%;
     height: 1.75em;
     left: 1em;
     bottom: .8em;
+}
+
+.manualIcon > img {
+    object-fit: contain;
+    object-position: left center;
 }
 
 .manual:hover .manualInner {

--- a/consts/hidden-manuals.js
+++ b/consts/hidden-manuals.js
@@ -1,3 +1,3 @@
-const HIDDEN_MANUALS = ['typical', 'typical-2', 'street-name-plates']
+const HIDDEN_MANUALS = ['typical', 'typical-2']
 
 export default HIDDEN_MANUALS

--- a/utils/getBackgroundColor.js
+++ b/utils/getBackgroundColor.js
@@ -1,7 +1,0 @@
-import Color from 'color'
-
-function getBackgroundColor(primaryColor) {
-    return Color(primaryColor).alpha(0.2).lighten(0.2).rgb()
-}
-
-export default getBackgroundColor

--- a/utils/getManualColorScheme.js
+++ b/utils/getManualColorScheme.js
@@ -1,0 +1,12 @@
+import Color from 'color'
+
+function getManualColorScheme(baseColor) {
+    const color = Color(baseColor)
+    return {
+        title: color.rgb(),
+        bgLight: color.alpha(0.2).lighten(0.2).rgb(),
+        bgDark: color.alpha(0.4).rgb(),
+    }
+}
+
+export default getManualColorScheme


### PR DESCRIPTION
- [x] Replace cover image to bg-color
- [x] Rename `getBackgroundColor` to `getManualColorScheme`
   - Now we have colors: `title`, `bgLight`, `bgDark`

![image](https://user-images.githubusercontent.com/22644149/208132857-33c278cd-1ae2-46b6-9c28-9a256f0e6f97.png)

Merge after #42 