### PR TITLE
Change font-size for Suggestions and TableOfContents

### DIFF
--- a/components/ManualPreview/ManualPreview.module.css
+++ b/components/ManualPreview/ManualPreview.module.css
@@ -153,10 +153,6 @@
         font-size: 1.2vw;
     }
 
-    .manualTitle {
-        margin-bottom: .15em;
-    }
-
     .manualInner {
         padding: 1em;
     }

--- a/components/SidePage/Suggestions/Suggestions.jsx
+++ b/components/SidePage/Suggestions/Suggestions.jsx
@@ -40,7 +40,7 @@ const SectionSuggestion = ({ section, colorHex }) => {
 
     return (
         <div>
-            <p style={{ color: colorHex, fontWeight: 500, fontSize: '18px', paddingTop: '28px' }}>
+            <p style={{ color: colorHex }} className={styles.SectionSuggestion__title}>
                 {sectionName}
             </p>
             <ul className={styles.SectionSuggestion__list}>
@@ -67,15 +67,12 @@ const GuideSuggestion = ({ guideSuggestion }) => {
     return (
         <article className={styles.GuideSuggestion}>
             <div className={styles.image__container}>
-                <Image className={styles.image} fill src={`${API_HOST}/static/${icon}`} />
+                <Image className={styles.image} fill src={`${API_HOST}/static/${icon}`} alt="" />
                 <h3
                     style={{
                         color: colorHex,
-                        position: 'absolute',
-                        top: '0px',
-                        left: '16px',
-                        fontSize: 'clamp(16px, 5vw, 24px)',
                     }}
+                    className={styles.GuideSuggestion__title}
                 >
                     {title}
                 </h3>

--- a/components/SidePage/Suggestions/Suggestions.module.css
+++ b/components/SidePage/Suggestions/Suggestions.module.css
@@ -24,14 +24,6 @@
     height: unset !important;
     border-radius: 8px;
 }
-  
-
-.GuideSuggestion__title {
-    display: flex;
-    flex-direction: row;
-    gap: 8px;
-    align-items: baseline;
-}
 
 .GuideSuggestion__icon {
     transform: translateY(8px);
@@ -43,9 +35,25 @@
     margin-bottom: 40px;
 }
 
+
+.GuideSuggestion__title {
+    position: absolute;
+    font-weight: 400;
+    margin-bottom: .15em;
+    font-size: 5vw;
+    top: 0;
+    padding: 0 16px;
+}
+
 .SectionSuggestion__list {
     list-style: none;
     padding-left: 0;
+}
+
+.SectionSuggestion__title {
+    font-weight: 500;
+    font-size: 20px;
+    padding-top: 28px;
 }
 
 .SuggestItem__target {
@@ -56,7 +64,7 @@
 .SuggestItem__link {
     text-decoration: none;
     color: #14283C;
-    font-size: 18px;
+    font-size: 16px;
 }
 
 .SuggestItem__listItem:hover > .SuggestItem__link {
@@ -73,4 +81,18 @@
 .SuggestItem__suggestionText {
     color: #14283C;
     opacity: 0.5;
+}
+
+
+@media screen and (min-width: 768px) {
+    .GuideSuggestion__title {
+        font-size: 2.5vw;
+    }
+}
+
+@media screen and (min-width: 991px) {
+    .GuideSuggestion__title {
+        font-size: 1.4vw;
+    }
+
 }

--- a/components/TableOfContents/TableOfContents.module.css
+++ b/components/TableOfContents/TableOfContents.module.css
@@ -171,7 +171,7 @@
     border-radius: 8px;
     transition: 0.2s;
     padding: 12px 16px 12px 16px;
-    font-size: 1rem;
+    font-size: 20px;
 }
 
 .tableOfContentsLink:hover,

--- a/components/TableOfContents/TableOfContents.module.css
+++ b/components/TableOfContents/TableOfContents.module.css
@@ -70,7 +70,6 @@
 .innerH3 {
     margin-left: 0px;
     padding-left: 16px !important;
-    font-size: 14px !important
 }
 
 .catalogTitle:hover,
@@ -134,7 +133,7 @@
     transition: 0.2s;
     padding: 12px 8px 12px 8px;
     position: relative;
-    font-size: 18px;
+    font-size: 16px;
     opacity: 0.8;
 }
 


### PR DESCRIPTION
Big size - 20px
Small size - 16px
Title of guide on the search page like title of guide on the main page

Before TableOfContents
<img width="410" alt="image" src="https://user-images.githubusercontent.com/5736291/217560412-c48fccb1-fd8d-4417-af43-5a98caac9a32.png">
After TableOfContents
<img width="389" alt="image" src="https://user-images.githubusercontent.com/5736291/217560124-70d090e4-3cb5-448d-8f76-d1c700f2270d.png">

Before Suggestions
<img width="400" alt="image" src="https://user-images.githubusercontent.com/5736291/217560606-504490fc-d258-45f5-8fe1-691ef2d462f5.png">
After Suggestions
<img width="392" alt="image" src="https://user-images.githubusercontent.com/5736291/217560214-41176c55-b656-4f8c-9a4e-a9bbbf2eda33.png">
