### PR TITLE
Change the visual display of search items

### DIFF
--- a/components/SidePage/Suggestions/Suggestions.jsx
+++ b/components/SidePage/Suggestions/Suggestions.jsx
@@ -16,9 +16,15 @@ const SuggestItem = (suggest) => {
     const { asPath } = useRouter()
     const currentSection = asPath.split('/').filter(Boolean).at(1)
     const link = `${origin}/${suggest?.suggest?.link}`
-    const leftText = suggest?.suggest?.text?.left
+    const leftText =
+        suggest?.suggest?.text?.left.length >= 3
+            ? '...' + suggest?.suggest?.text?.left
+            : suggest?.suggest?.text?.left
     const target = suggest?.suggest?.text?.target
-    const rightText = suggest?.suggest?.text?.right
+    const rightText =
+        suggest?.suggest?.text?.right.length >= 3
+            ? suggest?.suggest?.text?.right + '...'
+            : suggest?.suggest?.text?.right
 
     return (
         <li className={styles.SuggestItem__listItem}>

--- a/components/SidePage/Suggestions/Suggestions.jsx
+++ b/components/SidePage/Suggestions/Suggestions.jsx
@@ -23,13 +23,10 @@ const SuggestItem = ({ suggest, colorHex }) => {
     const rightText =
         suggest?.text?.right.length >= 3 ? suggest?.text?.right + '...' : suggest?.text?.right
 
-    const colorScheme = getManualColorScheme(colorHex)
+    const backgroundColor = getManualColorScheme(colorHex).bgLight.alpha(0.05)
 
     return (
-        <li
-            className={styles.SuggestItem__listItem}
-            style={{ backgroundColor: colorScheme.bgLight }}
-        >
+        <li className={styles.SuggestItem__listItem} style={{ backgroundColor }}>
             <Link
                 className={styles.SuggestItem__link}
                 href={link.includes(currentSection) ? '' : link}

--- a/components/SidePage/Suggestions/Suggestions.jsx
+++ b/components/SidePage/Suggestions/Suggestions.jsx
@@ -5,8 +5,9 @@ import { useRouter } from 'next/router'
 
 import { API_HOST } from '../../../consts/endpoints'
 import styles from './Suggestions.module.css'
+import getManualColorScheme from '../../../utils/getManualColorScheme.js'
 
-const SuggestItem = (suggest) => {
+const SuggestItem = ({ suggest, colorHex }) => {
     const [origin, setOrigin] = useState('')
 
     useEffect(() => {
@@ -15,19 +16,20 @@ const SuggestItem = (suggest) => {
 
     const { asPath } = useRouter()
     const currentSection = asPath.split('/').filter(Boolean).at(1)
-    const link = `${origin}/${suggest?.suggest?.link}`
+    const link = `${origin}/${suggest?.link}`
     const leftText =
-        suggest?.suggest?.text?.left.length >= 3
-            ? '...' + suggest?.suggest?.text?.left
-            : suggest?.suggest?.text?.left
-    const target = suggest?.suggest?.text?.target
+        suggest?.text?.left.length >= 3 ? '...' + suggest?.text?.left : suggest?.text?.left
+    const target = suggest?.text?.target
     const rightText =
-        suggest?.suggest?.text?.right.length >= 3
-            ? suggest?.suggest?.text?.right + '...'
-            : suggest?.suggest?.text?.right
+        suggest?.text?.right.length >= 3 ? suggest?.text?.right + '...' : suggest?.text?.right
+
+    const colorScheme = getManualColorScheme(colorHex)
 
     return (
-        <li className={styles.SuggestItem__listItem}>
+        <li
+            className={styles.SuggestItem__listItem}
+            style={{ backgroundColor: colorScheme.bgLight }}
+        >
             <Link
                 className={styles.SuggestItem__link}
                 href={link.includes(currentSection) ? '' : link}
@@ -51,7 +53,7 @@ const SectionSuggestion = ({ section, colorHex }) => {
             </p>
             <ul className={styles.SectionSuggestion__list}>
                 {suggestions?.map((suggest) => (
-                    <SuggestItem suggest={suggest} />
+                    <SuggestItem suggest={suggest} colorHex={colorHex} />
                 ))}
             </ul>
         </div>

--- a/components/SidePage/Suggestions/Suggestions.jsx
+++ b/components/SidePage/Suggestions/Suggestions.jsx
@@ -17,11 +17,9 @@ const SuggestItem = ({ suggest, colorHex }) => {
     const { asPath } = useRouter()
     const currentSection = asPath.split('/').filter(Boolean).at(1)
     const link = `${origin}/${suggest?.link}`
-    const leftText =
-        suggest?.text?.left.length >= 3 ? '...' + suggest?.text?.left : suggest?.text?.left
+    const leftText = suggest?.text?.left
     const target = suggest?.text?.target
-    const rightText =
-        suggest?.text?.right.length >= 3 ? suggest?.text?.right + '...' : suggest?.text?.right
+    const rightText = suggest?.text?.right
 
     const backgroundColor = getManualColorScheme(colorHex).bgLight.alpha(0.05)
 

--- a/components/SidePage/Suggestions/Suggestions.module.css
+++ b/components/SidePage/Suggestions/Suggestions.module.css
@@ -78,7 +78,6 @@
     margin-bottom: 16px;
     padding: 16px;
     border-radius: 12px;
-    background-color: #f0f2f4;
 }
 
 .SuggestItem__suggestionText {

--- a/components/SidePage/Suggestions/Suggestions.module.css
+++ b/components/SidePage/Suggestions/Suggestions.module.css
@@ -57,7 +57,7 @@
 }
 
 .SuggestItem__target {
-    font-weight: 600;
+    font-weight: 500;
     color: #14283C;
 }
 
@@ -76,6 +76,9 @@
 
 .SuggestItem__listItem {
     margin-bottom: 16px;
+    padding: 16px;
+    border-radius: 12px;
+    background-color: #f0f2f4;
 }
 
 .SuggestItem__suggestionText {

--- a/components/SidePage/Suggestions/Suggestions.module.css
+++ b/components/SidePage/Suggestions/Suggestions.module.css
@@ -75,9 +75,9 @@
 }
 
 .SuggestItem__listItem {
-    margin-bottom: 16px;
+    margin-bottom: 8px;
     padding: 16px;
-    border-radius: 12px;
+    border-radius: 8px;
 }
 
 .SuggestItem__suggestionText {


### PR DESCRIPTION
- [x] Add a background plate for each issue (to make it visually clear that these are different issues) + increase the distance between the items so that they do not stick together with the added plates
- [x] Reduce the thickness of letters in words around the selected word: from 600 to 500

Before
<img width="388" alt="image" src="https://user-images.githubusercontent.com/5736291/218315785-c5879ef9-ad10-45bb-8734-3e0ce0161f3f.png">
After
<img width="392" alt="image" src="https://user-images.githubusercontent.com/5736291/218315766-829d56a2-a22f-42cb-986b-fa0e24d042bc.png">
