### PR TITLE
Fix Next.js errors & warnings

### DIFF
--- a/components/ArrowNavLink/ArrowNavLink.jsx
+++ b/components/ArrowNavLink/ArrowNavLink.jsx
@@ -15,7 +15,6 @@ export function ArrowNavLink({
     tableOfContentArr,
     pageUrl,
     catalogIndex,
-    children,
     color,
     textDecoration,
 }) {
@@ -32,14 +31,6 @@ export function ArrowNavLink({
         const nextCatalogIndex = catalogIndex + 1
         if (Number.isNaN(nextCatalogIndex)) {
             return nextCatalogIndex - 1
-        }
-        if (nextCatalogIndex >= children.length) {
-            title = 'Назад к руководствам'
-            href = { pathname: '/' }
-        } else {
-            const nextCatalog = getCatalogOptions(children[nextCatalogIndex])
-            title = nextCatalog.title
-            href.query.pageUrl = [nextCatalog.url]
         }
     }
 

--- a/components/ManualPage/ManualPage.jsx
+++ b/components/ManualPage/ManualPage.jsx
@@ -32,7 +32,6 @@ function ManualPage({
     pageUrl,
     nextPageIndex,
     catalogIndex,
-    children,
     pageImage,
 }) {
     const { asPath } = useRouter()
@@ -165,9 +164,7 @@ function ManualPage({
                                 pageUrl={pageUrl}
                                 color={color}
                                 textDecoration={colorScheme.textDecoration}
-                            >
-                                {children}
-                            </ArrowNavLink>
+                            />
                         )}
                     </nav>
                 )}

--- a/components/NotionTypes/GuideImage/GuideImage.jsx
+++ b/components/NotionTypes/GuideImage/GuideImage.jsx
@@ -44,7 +44,7 @@ function GuideImage({ notionType }) {
                 slides={[{ src: srcUrl }]}
                 {...lightboxOptions}
             />
-            <Image onClick={() => setOpen(true)} className={cn} src={srcUrl} fill />
+            <Image onClick={() => setOpen(true)} className={cn} src={srcUrl} fill alt="" />
         </>
     )
 

--- a/components/TableOfContents/TableOfContents.jsx
+++ b/components/TableOfContents/TableOfContents.jsx
@@ -85,7 +85,6 @@ function TableOfContents({ tableOfContentArr, currentPageUrl = [], anchorLinks, 
                     href={{
                         pathname: '/[[...pageUrl]]',
                         query: { pageUrl: [currentPageUrl[0], url] },
-                        as: `${currentPageUrl.join('/')}/${url}`,
                     }}
                     style={{
                         color: colorScheme.title,
@@ -150,6 +149,7 @@ function TableOfContents({ tableOfContentArr, currentPageUrl = [], anchorLinks, 
     return (
         <>
             <Head>
+                <meta name="theme-color" content={color} />
                 <title>{catalogTitle}</title>
             </Head>
             <aside className={styles.TableOfContents__aside}>

--- a/components/TableOfContents/TableOfContents.jsx
+++ b/components/TableOfContents/TableOfContents.jsx
@@ -149,7 +149,6 @@ function TableOfContents({ tableOfContentArr, currentPageUrl = [], anchorLinks, 
     return (
         <>
             <Head>
-                <meta name="theme-color" content={color} />
                 <title>{catalogTitle}</title>
             </Head>
             <aside className={styles.TableOfContents__aside}>

--- a/components/Toolbar/Toolbar.jsx
+++ b/components/Toolbar/Toolbar.jsx
@@ -18,7 +18,7 @@ export const Toolbar = ({ toolbarColor = '#f5f8fb', colorTitle = '#1A1C1F', pdfU
     const [isOpenSidePage, setIsOpenSidePage] = useState(false)
     const [isLoadingSuggestion, setIsLoadingSuggestion] = useState(false)
     const [currentQuery, setCurrentQuery] = useState('')
-    const searchInputRef = React.useRef(null)
+    const searchInputRef = useRef(null)
     const [guideSuggestions, setGuideSuggestions] = useState([])
 
     const handleOnChange = useCallback(

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		}
 	},
 	"dependencies": {
-		"@next/font": "13.5.6",
 		"@popperjs/core": "2.11.8",
 		"bootstrap": "5.3.2",
 		"classnames": "2.3.2",

--- a/pages/manuals/[[...pageUrl]].jsx
+++ b/pages/manuals/[[...pageUrl]].jsx
@@ -17,10 +17,10 @@ export const PageContext = createContext(null)
 export const TocStateContext = createContext(null)
 
 function GetPage({
-    children,
-    pageList,
+    catalogTitle,
+    catalogIndex,
     pageName,
-    catalogPage,
+    pageList,
     pageImage,
     colorMap,
     iconMap,
@@ -36,10 +36,6 @@ function GetPage({
     const [nextPageIndex, setNexPageIndex] = useState(null)
     const [anchorLinks, setAnchorLinks] = useState([])
     const [isOpen, setIsOpen] = useState(isDesktop)
-
-    const [catalogTitle, setCatalogTitle] = useState('')
-    const [catalogId, setCatalogId] = useState('')
-    const [catalogIndex, setCatalogIndex] = useState()
 
     const getColumnItem = (columnItem) => {
         const getLine = (columnList) => {
@@ -74,24 +70,6 @@ function GetPage({
                 return null
         }
     }
-
-    useEffect(() => {
-        if (!catalogPage) {
-            return
-        }
-
-        setCatalogTitle(catalogPage.content.title)
-        setCatalogId(catalogPage.id)
-    }, [catalogPage])
-
-    useEffect(() => {
-        if (!children || !catalogId || catalogId === '') {
-            return
-        }
-
-        const catalogIndexForSet = children.findIndex((catalog) => catalog.id === catalogId)
-        setCatalogIndex(catalogIndexForSet)
-    }, [children, catalogId])
 
     useEffect(() => {
         if (manualToc.length === 0 || !pageUrl) {
@@ -135,7 +113,6 @@ function GetPage({
                     <ManualPage
                         pageList={pageList}
                         pageName={pageName}
-                        children={children}
                         tableOfContentArr={manualToc}
                         nextPageIndex={nextPageIndex}
                         catalogIndex={catalogIndex}
@@ -185,12 +162,14 @@ export async function getServerSideProps({ params: { pageUrl } }) {
             url: children?.properties?.pageUrl?.url ?? null,
         }
     })
+
     const iconMap = children.map((children) => {
         return {
             imageUrl: `${API_HOST}/static/${children?.properties?.previewImage[0]}` ?? null,
             url: children?.properties?.pageUrl?.url ?? null,
         }
     })
+
     const pdfUrlsMap = children.map((children) => {
         return {
             pdfUrl: children?.properties?.pdfUrl?.url ?? null,
@@ -198,13 +177,19 @@ export async function getServerSideProps({ params: { pageUrl } }) {
         }
     })
 
+    const catalogPage = await getPageByUrl(catalogPathname)
+    const catalogIndex = children.findIndex((catalog) => catalog.id === catalogPage.id)
+    const catalogTitle = catalogPage.content.title
+    const pageImage = page?.node_properties?.cover
+
     return {
         props: {
-            children,
+            catalogPage,
+            catalogTitle,
+            catalogIndex,
             pageName,
             pageList,
-            pageImage: page?.node_properties?.cover,
-            catalogPage: await getPageByUrl(pageUrl[0]),
+            pageImage,
             colorMap,
             iconMap,
             pdfUrlsMap,

--- a/pages/manuals/[[...pageUrl]].jsx
+++ b/pages/manuals/[[...pageUrl]].jsx
@@ -37,9 +37,9 @@ function GetPage({
     const [anchorLinks, setAnchorLinks] = useState([])
     const [isOpen, setIsOpen] = useState(isDesktop)
 
-    const [catalogTitle, setCatalogTitle] = React.useState('')
-    const [catalogId, setCatalogId] = React.useState('')
-    const [catalogIndex, setCatalogIndex] = React.useState()
+    const [catalogTitle, setCatalogTitle] = useState('')
+    const [catalogId, setCatalogId] = useState('')
+    const [catalogIndex, setCatalogIndex] = useState()
 
     const getColumnItem = (columnItem) => {
         const getLine = (columnList) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@next/font':
-    specifier: 13.5.6
-    version: 13.5.6
   '@popperjs/core':
     specifier: 2.11.8
     version: 2.11.8
@@ -602,10 +599,6 @@ packages:
     resolution: {integrity: sha512-ng7pU/DDsxPgT6ZPvuprxrkeew3XaRf4LAT4FabaEO/hAbvVx4P7wqnqdbTdDn1kgTvsI4tpIgT4Awn/m0bGbg==}
     dependencies:
       glob: 7.1.7
-
-  /@next/font@13.5.6:
-    resolution: {integrity: sha512-urmUq05uCVJsBqAAJEV+xK5OTTodrSxdiG+351SOSjlWctywdBM6qX+K9pIe3K48RxjfnxlBbXjGyOJAji+pfw==}
-    dev: false
 
   /@next/swc-darwin-arm64@13.5.6:
     resolution: {integrity: sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==}

--- a/utils/font.js
+++ b/utils/font.js
@@ -1,4 +1,4 @@
-import localFont from '@next/font/local'
+import localFont from 'next/font/local'
 
 export const isetSansFont = localFont({
     src: [


### PR DESCRIPTION
I cleaned up the errors in the console

**Fix manual warning fixes**
- [x] Removed unused `as` attribute from `<Link>`
```
Warning: Unknown key passed via urlObject into url.format: as
```

- [x] Deleted unused huge object `children`
```
Warning: data for page "/manuals/[[...pageUrl]]" (path "/city-centre-design-code/problems") is 140 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance.
```

- [x] Remove `@next/font` package — now it's default module from Next.js
```
 ⚠ Your project has `@next/font` installed as a dependency, please use the built-in `next/font` instead. The `@next/font` package will be removed in Next.js 14. You can migrate by running `pnpm dlx @next/codemod@latest built-in-next-font .`. Read more: https://nextjs.org/docs/messages/built-in-next-font
```

**Fix React client-side errors**
- [x] Add `alt` to `<Image>`
- [x] Remove `useState` calculations. Move it to server-side
